### PR TITLE
AS-214 Setting Max Current and Profile Velocity in GoToTargetPosition()

### DIFF
--- a/PDxx/PDxxPLC/PDxxPLC.plcproj
+++ b/PDxx/PDxxPLC/PDxxPLC.plcproj
@@ -19,7 +19,7 @@
     <Company>iMusic AS</Company>
     <Released>false</Released>
     <Title>PDxx</Title>
-    <ProjectVersion>0.0.1.3</ProjectVersion>
+    <ProjectVersion>0.2.0.1</ProjectVersion>
     <LibraryCategories>
       <LibraryCategory xmlns="">
         <Id>{1ae6d400-55f5-48a0-9fa9-d6a1ce9670ee}</Id>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -469,13 +469,19 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[diff := GetPosition() - nPosition;
-IF diff = 0 THEN
-	bTrig := FALSE;
-ELSIF SetTargetPosition(nRequestedPosition := nPosition) = TRUE THEN
-	bTrig := StartMoveToTargetPosition();
+
+IF fbSdoMaxCurrentValue <> nMaxCurrent THEN
+	SetMaxCurrent(nMaxCurrent);
 ELSE
-	// This never happens at the moment,  but kept it here as reminder if the ELSIF statement above starts returning false.
-	bTrig := FALSE;
+	SetProfileVelocity(nVelocity);
+	IF diff = 0 THEN
+		bTrig := FALSE;
+	ELSIF SetTargetPosition(nRequestedPosition := nPosition) = TRUE THEN
+		bTrig := StartMoveToTargetPosition();
+	ELSE
+		// This never happens at the moment,  but kept it here as reminder if the ELSIF statement above starts returning false.
+		bTrig := FALSE;
+	END_IF
 END_IF
 
 GoToTargetPosition := diff;]]></ST>
@@ -490,12 +496,11 @@ VAR_INPUT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF fbSdoMaxCurrentValue <> nMaxCurrent THEN
+        <ST><![CDATA[IF fbSdoMaxCurrentValue <> nMaxCurrent THEN
 	SetMaxCurrent(nMaxCurrent);
 ELSE
 	IF SetVelocityMode() THEN
-		SetVelocity(-nVelocity); // It is negative because we want to move towards the closed position zero point from a positive valued open gripper.
+		SetTargetVelocity(-nVelocity); // It is negative because we want to move towards the closed position zero point from a positive valued open gripper.
 	END_IF	
 END_IF
 
@@ -516,7 +521,7 @@ END_VAR
 	SetMaxCurrent(nMaxCurrent);
 ELSE
 	IF SetVelocityMode() THEN
-		SetVelocity(-nVelocity); // It is negative because we want to move towards the closed position zero point from a positive valued open gripper.
+		SetTargetVelocity(-nVelocity); // It is negative because we want to move towards the closed position zero point from a positive valued open gripper.
 	END_IF	
 END_IF
 
@@ -549,7 +554,7 @@ END_VAR]]></Declaration>
 	determine whether a end limit has been found. *)
 
 IF SetVelocityMode() THEN
-	SetVelocity(nVelocity);
+	SetTargetVelocity(nVelocity);
 ELSE
 	Status.nMaxActualPosition := GetActualPosition();
 	Status.nMinActualPosition := GetActualPosition();
@@ -796,6 +801,23 @@ ELSE
 END_IF]]></ST>
       </Implementation>
     </Method>
+    <Method Name="SetProfileVelocity" Id="{161b5e1d-59d0-46cc-9f23-9c7e3207a614}">
+      <Declaration><![CDATA[
+METHOD PUBLIC SetProfileVelocity
+VAR_INPUT
+	nVelocity : INT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+IF nVelocity < 0 THEN
+	stPDOs.RxPDO_2_6081h_ProfileVelocity := INT_TO_UDINT(-nVelocity);
+ELSE
+	stPDOs.RxPDO_2_6081h_ProfileVelocity := INT_TO_UDINT(nVelocity);	
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="SetRangeForDigitalInput" Id="{88afb56b-e19f-436e-99ed-ec7a8a68dc03}">
       <Declaration><![CDATA[METHOD PUBLIC SetRangeForDigitalInput : BOOL
 VAR_INPUT
@@ -920,8 +942,8 @@ END_IF
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="SetVelocity" Id="{58b76007-4f62-471c-9884-97a933b7dfae}">
-      <Declaration><![CDATA[METHOD PUBLIC SetVelocity
+    <Method Name="SetTargetVelocity" Id="{58b76007-4f62-471c-9884-97a933b7dfae}">
+      <Declaration><![CDATA[METHOD PUBLIC SetTargetVelocity
 VAR_INPUT
 	nVelocity : INT;
 END_VAR
@@ -945,7 +967,7 @@ END_VAR
 	E_PDxx_State.READY_TO_SWITCH_ON:
 		SwitchOnPowerToMotor();
 	E_PDxx_State.SWITCHED_ON:
-		SetVelocity(0);
+		SetTargetVelocity(0);
 		IF eModesOfOperation <> E_PDxx_ModesOfOperation.VELOCITY_MODE THEN
 			ChangeModesOfOperation(E_PDxx_ModesOfOperation.VELOCITY_MODE);
 		ELSE

--- a/PDxx/PDxxPLC/Version/Global_Version.TcGVL
+++ b/PDxx/PDxxPLC/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 0, iBuild := 1, iRevision := 3, nFlags := 0, sVersion := '0.0.1.3');
+	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 0, iRevision := 1, nFlags := 0, sVersion := '0.2.0.1');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
Up until now the current and velocity was actually not set for a GoToTargetPosition() move, but relied on what had previously been set. This has been changed now so that before executing the move, the function first sets the maximum current for the motor and afterwards the maximum allowable velocity on the S-curve.
I renamed `SetVelocity()` to `SetTargetVelocity`() and implemented a new method `SetProfileVelocity()`, which takes an `INT` as input, which it then transforms into a `UDINT` internally. This latter should be ok as the method will always called from within GoToTargetPosition(), and so the velocity specified in that call will always be in regards to reaching to stated target. The inverse does not make sense.