### PR TITLE
AS-249 Add ability to set Acceleration in Profile Position Mode

### DIFF
--- a/PDxx/PDxxPLC/PDxxPLC.plcproj
+++ b/PDxx/PDxxPLC/PDxxPLC.plcproj
@@ -17,9 +17,9 @@
     <Implicit_Jitter_Distribution>{26b198da-1bb0-499c-813b-5f7bf4afb7a2}</Implicit_Jitter_Distribution>
     <LibraryReferences>{ab2cf576-b3cd-4536-a446-fb6d3b8d76ca}</LibraryReferences>
     <Company>iMusic AS</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>PDxx</Title>
-    <ProjectVersion>0.2.0.1</ProjectVersion>
+    <ProjectVersion>0.2.1.0</ProjectVersion>
     <LibraryCategories>
       <LibraryCategory xmlns="">
         <Id>{1ae6d400-55f5-48a0-9fa9-d6a1ce9670ee}</Id>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -45,6 +45,13 @@ VAR_INPUT
 	
 	fbSdoSIUnitPosition				: FB_SDO	:= (CO_Index:=16#60A8, CO_SubIndex:=16#0, DataLength:=4, 	CO_Name:='SI Unit Position', 		stCANopenDevice:=stCANopenDevice);
 	fbSdoSIUnitPositionValue		: UDINT;
+	
+	fbSdoProfileAcceleration		: FB_SDO	:= (CO_Index:=16#6083, CO_SubIndex:=16#0, DataLength:=4, 	CO_Name:='Profile Acceleration', 	stCANopenDevice:=stCANopenDevice);
+	fbSdoProfileAccelerationValue	: UDINT;
+
+	fbSdoProfileDeceleration		: FB_SDO	:= (CO_Index:=16#6084, CO_SubIndex:=16#0, DataLength:=4, 	CO_Name:='Profile Deceleration', 	stCANopenDevice:=stCANopenDevice);
+	fbSdoProfileDecelerationValue	: UDINT;
+
 END_VAR
 
 VAR_OUTPUT
@@ -769,6 +776,62 @@ IF fbSdoMaxCurrentValue = nMaxCurrent THEN
 	SetMaxCurrent := TRUE;
 ELSE
 	SetMaxCurrent := FALSE;
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="SetProfileAcceleration" Id="{3101720c-b6e2-474f-9dab-adf8a8b87c4a}">
+      <Declaration><![CDATA[
+METHOD PUBLIC SetProfileAcceleration : BOOL
+VAR_INPUT
+	nProfileAcceleration : UDINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+fbSdoProfileAcceleration.SetWriteDataFromUDINT(nProfileAcceleration);
+fbSdoProfileAcceleration(bStartReading := TRUE, bStartWriting := TRUE);
+
+IF SimParameters.bActivateSimulation = TRUE THEN
+	fbSdoProfileAccelerationValue := nProfileAcceleration;
+ELSE
+	IF fbSdoProfileAcceleration.ReadDataAvailable THEN
+		fbSdoProfileAccelerationValue := fbSdoProfileAcceleration.GetReadDataAsUDINT();
+	END_IF
+END_IF
+		
+IF fbSdoProfileAccelerationValue = nProfileAcceleration THEN
+	SetProfileAcceleration := TRUE;
+ELSE
+	SetProfileAcceleration := FALSE;
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="SetProfileDeceleration" Id="{f4aeb416-e264-440d-8b38-f9c05ff6bd0e}">
+      <Declaration><![CDATA[
+METHOD PUBLIC SetProfileDeceleration : BOOL
+VAR_INPUT
+	nProfileDeceleration : UDINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+fbSdoProfileDeceleration.SetWriteDataFromUDINT(nProfileDeceleration);
+fbSdoProfileDeceleration(bStartReading := TRUE, bStartWriting := TRUE);
+
+IF SimParameters.bActivateSimulation = TRUE THEN
+	fbSdoProfileDecelerationValue := nProfileDeceleration;
+ELSE
+	IF fbSdoProfileDeceleration.ReadDataAvailable THEN
+		fbSdoProfileDecelerationValue := fbSdoProfileDeceleration.GetReadDataAsUDINT();
+	END_IF
+END_IF
+		
+IF fbSdoProfileDecelerationValue = nProfileDeceleration THEN
+	SetProfileDeceleration := TRUE;
+ELSE
+	SetProfileDeceleration := FALSE;
 END_IF
 ]]></ST>
       </Implementation>

--- a/PDxx/PDxxPLC/Version/Global_Version.TcGVL
+++ b/PDxx/PDxxPLC/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 0, iRevision := 1, nFlags := 0, sVersion := '0.2.0.1');
+	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 1, iRevision := 0, nFlags := 0, sVersion := '0.2.1.0');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/PDxx/_Config/PLC/PDxxPLC.xti
+++ b/PDxx/_Config/PLC/PDxxPLC.xti
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.53" ClassName="CNestedPlcProjDef">
 	<Project GUID="{4E346434-4A57-47A1-B110-BE3BED7EDEC7}" Name="PDxxPLC" PrjFilePath="..\..\PDxxPLC\PDxxPLC.plcproj" TmcFilePath="..\..\PDxxPLC\PDxxPLC.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="PDxxPLC\PDxxPLC.tmc" TmcHash="{2EEB0EA4-0F66-D995-E9B9-A5FB0885795C}">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="PDxxPLC\PDxxPLC.tmc" TmcHash="{D4942F62-2DD8-370A-E512-A6D5E30B5BCF}">
 			<Name>PDxxPLC Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
 			<Vars VarGrpType="1">


### PR DESCRIPTION
`SetProfileAcceleration()` and `SetProfileDeceleration` respectively sets the acceleration and breaking deceleration in the Profile Position Mode. Note that arguments are expected to be UDINT and currently is in RPM/s (Revolutions Per Minute per second).