### PR TITLE
AS-60 Handle FAULT condition 

### DIFF
--- a/PDxx/PDxxPLC/PDxxPLC.plcproj
+++ b/PDxx/PDxxPLC/PDxxPLC.plcproj
@@ -17,9 +17,9 @@
     <Implicit_Jitter_Distribution>{26b198da-1bb0-499c-813b-5f7bf4afb7a2}</Implicit_Jitter_Distribution>
     <LibraryReferences>{ab2cf576-b3cd-4536-a446-fb6d3b8d76ca}</LibraryReferences>
     <Company>iMusic AS</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>PDxx</Title>
-    <ProjectVersion>0.2.1.0</ProjectVersion>
+    <ProjectVersion>0.2.2.0</ProjectVersion>
     <LibraryCategories>
       <LibraryCategory xmlns="">
         <Id>{1ae6d400-55f5-48a0-9fa9-d6a1ce9670ee}</Id>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -364,6 +364,10 @@ ELSIF 	NOT stStatusWord.SwitchOnDisabled									AND LowerNibble = 2#1000 THEN	e
 ELSE																										eState := E_PDxx_State.UNKNOWN_STATE;	
 END_IF
 
+IF eState = E_PDxx_State.FAULT THEN
+	ChangeState(E_PDxx_State.SWITCH_ON_DISABLED);
+END_IF
+
 Status.nCurrentPosition := GetPosition();
 Status.nCurrentVelocity := GetVelocity();]]></ST>
       </Implementation>

--- a/PDxx/PDxxPLC/Version/Global_Version.TcGVL
+++ b/PDxx/PDxxPLC/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 1, iRevision := 0, nFlags := 1, sVersion := '0.2.1.0');
+	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 2, iRevision := 0, nFlags := 0, sVersion := '0.2.2.0');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
We already had a code block that was supposed to handle if a FAULT State arises in PDxx.
```
// We check first if we need to recover from a Fault state
IF eState = E_PDxx_State.FAULT AND eState <> eRequestedState THEN
	stControlWord.FaultReset_bit_7		:= TRUE;	// "Fault reset" transition 13
	ControlWord.7 := stControlWord.FaultReset_bit_7;
	stPDOs.RxPDO_1_6040h_ControlWord := ControlWord;
	RETURN;
END_IF
```
The problem was that at least during ShelfController's Reset routine, the code block never reached execution, because the relevant code block was in the method `ChangeState`, which is not called during the Reset routine when `FB_PDxx.eState` is `E_PDxx_State.FAULT`

To solve this issue we take the method that checks the state, and if a FAULT State is encountered, then we call `ChangeState` immediately to make sure the intended FAULT handling code actually gets executed.

```
IF eState = E_PDxx_State.FAULT THEN
	ChangeState(E_PDxx_State.SWITCH_ON_DISABLED);
END_IF
```