### PR TITLE
AS-352 Make sure reference initial positions during zeroing are instance variables

### DIFF
--- a/PDxx/PDxxPLC/PDxxPLC.plcproj
+++ b/PDxx/PDxxPLC/PDxxPLC.plcproj
@@ -17,9 +17,9 @@
     <Implicit_Jitter_Distribution>{26b198da-1bb0-499c-813b-5f7bf4afb7a2}</Implicit_Jitter_Distribution>
     <LibraryReferences>{ab2cf576-b3cd-4536-a446-fb6d3b8d76ca}</LibraryReferences>
     <Company>iMusic AS</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>PDxx</Title>
-    <ProjectVersion>0.2.2.0</ProjectVersion>
+    <ProjectVersion>0.2.3.0</ProjectVersion>
     <LibraryCategories>
       <LibraryCategory xmlns="">
         <Id>{1ae6d400-55f5-48a0-9fa9-d6a1ce9670ee}</Id>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -547,7 +547,8 @@ GripThickness := GetPosition() - nObjectThickness;]]></ST>
       </Implementation>
     </Method>
     <Method Name="ProbeActualPositionLimits" Id="{7c7a05fe-7539-41c4-b37c-8f8bb00e3d51}">
-      <Declaration><![CDATA[METHOD PUBLIC ProbeActualPositionLimits : BOOL
+      <Declaration><![CDATA[
+METHOD PUBLIC ProbeActualPositionLimits : BOOL
 VAR_INPUT
 	nVelocity : INT;
 END_VAR
@@ -560,9 +561,11 @@ END_VAR
 VAR
 	nActualVelocity			: INT;
 	nActualPosition			: DINT;
-END_VAR]]></Declaration>
+END_VAR
+]]></Declaration>
       <Implementation>
-        <ST><![CDATA[(* 	Returns true whenever the method was able to push past
+        <ST><![CDATA[
+(* 	Returns true whenever the method was able to push past
 	one of the limits. External function can monitor how 
 	long this method has returned FALSE, in order to 
 	determine whether a end limit has been found. *)
@@ -599,7 +602,8 @@ ELSE
 	ELSE
 		ProbeActualPositionLimits := TRUE;		
 	END_IF
-END_IF]]></ST>
+END_IF
+]]></ST>
       </Implementation>
     </Method>
     <Method Name="ReleaseGripToThicknessMargin" Id="{bac69037-d9ae-4417-875b-6060a2afe036}">

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -552,10 +552,13 @@ VAR_INPUT
 	nVelocity : INT;
 END_VAR
 
-VAR
-	nActualVelocity			: INT;
+VAR_INST
 	nMinStartActualPosition : DINT;
 	nMaxStartActualPosition : DINT;
+END_VAR
+
+VAR
+	nActualVelocity			: INT;
 	nActualPosition			: DINT;
 END_VAR]]></Declaration>
       <Implementation>

--- a/PDxx/PDxxPLC/Version/Global_Version.TcGVL
+++ b/PDxx/PDxxPLC/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 2, iRevision := 0, nFlags := 1, sVersion := '0.2.2.0');
+	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 3, iRevision := 0, nFlags := 0, sVersion := '0.2.3.0');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
When zeroing a PDxx motor, the variables `nMinStartActualPosition` and `nMaxStartActualPosition` were set to the actual position of the motor during the first initial cycles of the method being called. Further on though, this value was reset to zero, because the variable was not an instance variables, and hence is initialised on every execution of the method.

Making these two variables `VAR_INST` makes them instance variables.