### PR TITLE
AS-325 Avoid Repeatedly setting the TargetPosition

### DIFF
--- a/PDxx/PDxxPLC/PDxxPLC.plcproj
+++ b/PDxx/PDxxPLC/PDxxPLC.plcproj
@@ -19,7 +19,7 @@
     <Company>iMusic AS</Company>
     <Released>false</Released>
     <Title>PDxx</Title>
-    <ProjectVersion>0.3.0.7</ProjectVersion>
+    <ProjectVersion>0.3.0.8</ProjectVersion>
     <LibraryCategories>
       <LibraryCategory xmlns="">
         <Id>{1ae6d400-55f5-48a0-9fa9-d6a1ce9670ee}</Id>

--- a/PDxx/PDxxPLC/PDxxPLC.plcproj
+++ b/PDxx/PDxxPLC/PDxxPLC.plcproj
@@ -17,9 +17,9 @@
     <Implicit_Jitter_Distribution>{26b198da-1bb0-499c-813b-5f7bf4afb7a2}</Implicit_Jitter_Distribution>
     <LibraryReferences>{ab2cf576-b3cd-4536-a446-fb6d3b8d76ca}</LibraryReferences>
     <Company>iMusic AS</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>PDxx</Title>
-    <ProjectVersion>0.2.3.0</ProjectVersion>
+    <ProjectVersion>0.3.0.7</ProjectVersion>
     <LibraryCategories>
       <LibraryCategory xmlns="">
         <Id>{1ae6d400-55f5-48a0-9fa9-d6a1ce9670ee}</Id>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -474,7 +474,6 @@ VAR_INPUT
 	nMaxCurrent	: UDINT;
 END_VAR
 VAR_INST
-	bTrig 		: BOOL	:= FALSE;
 	diff 		: DINT;
 END_VAR
 ]]></Declaration>
@@ -485,13 +484,10 @@ IF fbSdoMaxCurrentValue <> nMaxCurrent THEN
 	SetMaxCurrent(nMaxCurrent);
 ELSE
 	SetProfileVelocity(nVelocity);
-	IF diff = 0 THEN
-		bTrig := FALSE;
-	ELSIF SetTargetPosition(nRequestedPosition := nPosition) = TRUE THEN
-		bTrig := StartMoveToTargetPosition();
-	ELSE
-		// This never happens at the moment,  but kept it here as reminder if the ELSIF statement above starts returning false.
-		bTrig := FALSE;
+	IF SetProfilePositionMode() = TRUE THEN
+		IF SetTargetPosition(nRequestedPosition := nPosition) = TRUE THEN
+			StartMoveToTargetPosition();
+		END_IF
 	END_IF
 END_IF
 
@@ -533,6 +529,7 @@ END_VAR
 ELSE
 	IF SetVelocityMode() THEN
 		SetTargetVelocity(-nVelocity); // It is negative because we want to move towards the closed position zero point from a positive valued open gripper.
+		Status.nTargetPosition := GetPosition();
 	END_IF	
 END_IF
 
@@ -623,18 +620,21 @@ END_VAR
       </Implementation>
     </Method>
     <Method Name="ResetControlWordBit4" Id="{fc92a71a-2d31-4fca-991a-9704be85d5f4}">
-      <Declaration><![CDATA[METHOD PRIVATE ResetControlWordBit4 : BOOL
+      <Declaration><![CDATA[
+METHOD PRIVATE ResetControlWordBit4 : BOOL
 VAR_INPUT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF stStatusWord.OperationModeSpecific_bit12 THEN
-	IF 	eState = E_PDxx_State.OPERATION_ENABLED AND 
-		eModesOfOperation = E_PDxx_ModesOfOperation.PROFILE_POSITION_MODE THEN
-		stControlWord.OperationModeSpecific_bit_4 := FALSE;
-		stPDOs.RxPDO_1_6040h_ControlWord.4 := stControlWord.OperationModeSpecific_bit_4;	
-	END_IF
-END_IF]]></ST>
+        <ST><![CDATA[
+IF eState = E_PDxx_State.OPERATION_ENABLED AND 
+   eModesOfOperation = E_PDxx_ModesOfOperation.PROFILE_POSITION_MODE AND
+   stControlWord.OperationModeSpecific_bit_4 = TRUE AND
+   stStatusWord.OperationModeSpecific_bit12 = TRUE THEN
+	stControlWord.OperationModeSpecific_bit_4 := FALSE;
+	stPDOs.RxPDO_1_6040h_ControlWord.4 := stControlWord.OperationModeSpecific_bit_4;	
+END_IF
+]]></ST>
       </Implementation>
     </Method>
     <Action Name="ResetStatusAndSDOs" Id="{6d8f9502-6686-48cc-8558-8b0271768af0}">
@@ -998,21 +998,23 @@ END_IF
       </Implementation>
     </Method>
     <Method Name="SetTargetPosition" Id="{f21760ba-70aa-4b6c-acd5-a0513af7c792}">
-      <Declaration><![CDATA[METHOD PRIVATE SetTargetPosition : BOOL
+      <Declaration><![CDATA[
+METHOD PRIVATE SetTargetPosition : BOOL
 VAR_INPUT
 	nRequestedPosition : DINT;
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF TRUE THEN
-// placeholder for making a boundary check or something before setting target position
+        <ST><![CDATA[
+IF Status.nTargetPosition <> nRequestedPosition AND
+   stStatusWord.OperationModeSpecific_bit12 = FALSE AND
+   stControlWord.OperationModeSpecific_bit_4 = FALSE THEN
 	Status.nTargetPosition := nRequestedPosition;
 	stPDOs.RxPDO_2_607Ah_TargetPosition := GetActualPositionFromNormalisedPosition(Status.nTargetPosition);
 	SetTargetPosition := TRUE;
 ELSE
 	SetTargetPosition := FALSE;
 END_IF
-
 ]]></ST>
       </Implementation>
     </Method>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -1131,6 +1131,7 @@ END_CASE
 
 IF eState = E_PDxx_State.SWITCH_ON_DISABLED THEN
 	SwitchOffPowerToMotor := TRUE;
+	Status.nTargetPosition := GetPosition();
 ELSE
 	SwitchOffPowerToMotor := FALSE;
 END_IF]]></ST>
@@ -1149,6 +1150,7 @@ END_CASE
 
 IF eState = E_PDxx_State.SWITCHED_ON THEN
 	SwitchOnPowerToMotor := TRUE;
+	Status.nTargetPosition := GetPosition();
 ELSE
 	SwitchOnPowerToMotor := FALSE;
 END_IF]]></ST>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.15">
   <POU Name="FB_PDxx" Id="{97c1bf8a-88d3-43c0-aca9-b8d8817bfdd0}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_PDxx
 
@@ -488,7 +488,6 @@ ELSE
 	IF SetProfilePositionMode() = TRUE THEN
 		IF SetTargetPosition(nRequestedPosition := nPosition) = TRUE THEN
 			startMoveInCycles := 2;
-//			StartMoveToTargetPosition();
 		END_IF
 		IF startMoveInCycles = 1 THEN
 			StartMoveToTargetPosition();

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -475,6 +475,7 @@ VAR_INPUT
 END_VAR
 VAR_INST
 	diff 		: DINT;
+	startMoveInCycles : ULINT := 0;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -486,7 +487,14 @@ ELSE
 	SetProfileVelocity(nVelocity);
 	IF SetProfilePositionMode() = TRUE THEN
 		IF SetTargetPosition(nRequestedPosition := nPosition) = TRUE THEN
+			startMoveInCycles := 2;
+//			StartMoveToTargetPosition();
+		END_IF
+		IF startMoveInCycles = 1 THEN
 			StartMoveToTargetPosition();
+			startMoveInCycles := 0;
+		ELSIF startMoveInCycles > 0 THEN
+			startMoveInCycles := startMoveInCycles - 1;
 		END_IF
 	END_IF
 END_IF

--- a/PDxx/PDxxPLC/Version/Global_Version.TcGVL
+++ b/PDxx/PDxxPLC/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 3, iBuild := 0, iRevision := 7, nFlags := 0, sVersion := '0.3.0.7');
+	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 3, iBuild := 0, iRevision := 8, nFlags := 0, sVersion := '0.3.0.8');
 END_VAR
 ]]></Declaration>
   </GVL>

--- a/PDxx/PDxxPLC/Version/Global_Version.TcGVL
+++ b/PDxx/PDxxPLC/Version/Global_Version.TcGVL
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.15">
   <GVL Name="Global_Version" Id="{53ae8b4c-8f21-4d21-8297-85127d0403a6}">
     <Declaration><![CDATA[{attribute 'TcGenerated'}
 {attribute 'no-analysis'}
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 2, iBuild := 3, iRevision := 0, nFlags := 1, sVersion := '0.2.3.0');
+	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 3, iBuild := 0, iRevision := 7, nFlags := 0, sVersion := '0.3.0.7');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
Up until know we have continuously been repeatedly setting the target position constantly, no matter if it was set or not.
I don't think it was an issue in itself (it has kinda worked up until now), but once in a while, when there was a hanging servo motor, it was almost impossible to figure out what was going on.

With this PR we have made sure we only set the target once, when we change it.
Essentially it checks if the target is already set to the new target we want to set it to, and if not, then we set it to that, and raise the bit in the control register (bit4) that communicates that we have set a new target.
We hold it high until the Nanotec motor respond with bit 12 in its status register, as an acknowledgement of new TargetPosition received.

With just this alteration it wouldn't work. We use to Modes of operation. ProfilePosition Mode which calculates velocity and acceleration curves from point to point, and Velocity Mode which just ramps velocity up/down to a fixed value.

Setting the TargetPosition is strictly for ProfilePosition Mode. When we switch the to Velocity Mode, the motor moves away from the current position, but the TargetPosition obviously doesn't change. If we set a TargetPosition at 20mm, for example, then close the gripper with VelocityMode, and then want to open to 20mm again, this rudimentary fix won't allow a new TargetPosition to be set (and hence inform the Nanotec servo), because it is the same target.

We solve this by updating the TargetPosition to whatever the actual position is whenever we use Velocity Mode, that way the TargetPosition because sort of "the last known intended position", and we conserve the idea of having the Nanotec motor figure out how to get to the intended position by itself when in ProfilePosition Mode, but not blocking for its behaviour when going to velocity mode.

Lastly we had to implement a similar behaviour (setting TargetPosition to Actual Position) when turning it on and off again. Essentially, whenever we interrupt a ProfilePosition Mode action, we need to make sure we can enter it again with any waypoint.