### PR TITLE
AS-677 - Under Voltage Fault Handling

### DIFF
--- a/PDxx/PDxxPLC/PDxxPLC.plcproj
+++ b/PDxx/PDxxPLC/PDxxPLC.plcproj
@@ -17,9 +17,9 @@
     <Implicit_Jitter_Distribution>{26b198da-1bb0-499c-813b-5f7bf4afb7a2}</Implicit_Jitter_Distribution>
     <LibraryReferences>{ab2cf576-b3cd-4536-a446-fb6d3b8d76ca}</LibraryReferences>
     <Company>iMusic AS</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Title>PDxx</Title>
-    <ProjectVersion>0.3.1.1</ProjectVersion>
+    <ProjectVersion>0.3.2.0</ProjectVersion>
     <LibraryCategories>
       <LibraryCategory xmlns="">
         <Id>{1ae6d400-55f5-48a0-9fa9-d6a1ce9670ee}</Id>

--- a/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
+++ b/PDxx/PDxxPLC/POUs/FB_PDxx.TcPOU
@@ -178,16 +178,17 @@ END_VAR
 VAR
 	ControlWord : UINT;
 END_VAR
-
-
-
+VAR_INST
+	bLastFaultResetBitState : BOOL;
+END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[ControlWord := 0;
 
 // We check first if we need to recover from a Fault state
 IF eState = E_PDxx_State.FAULT AND eState <> eRequestedState THEN
-	stControlWord.FaultReset_bit_7		:= TRUE;	// "Fault reset" transition 13
+	bLastFaultResetBitState := bLastFaultResetBitState XOR 1; 
+	stControlWord.FaultReset_bit_7		:= bLastFaultResetBitState;	// "Fault reset" transition 13 on rising edge
 	ControlWord.7 := stControlWord.FaultReset_bit_7;
 	stPDOs.RxPDO_1_6040h_ControlWord := ControlWord;
 	RETURN;

--- a/PDxx/PDxxPLC/Version/Global_Version.TcGVL
+++ b/PDxx/PDxxPLC/Version/Global_Version.TcGVL
@@ -7,7 +7,7 @@
 // This function has been automatically generated from the project information.
 VAR_GLOBAL CONSTANT
 	{attribute 'const_non_replaced'}
-	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 3, iBuild := 1, iRevision := 1, nFlags := 1, sVersion := '0.3.1.1');
+	stLibVersion_PDxx : ST_LibVersion := (iMajor := 0, iMinor := 3, iBuild := 2, iRevision := 0, nFlags := 0, sVersion := '0.3.2.0');
 END_VAR
 ]]></Declaration>
   </GVL>


### PR DESCRIPTION
We had an issue with Nanotech motors not coming back out of fault mode when Under voltage.
This was due to the fault reset being automatically triggered immediately as encountered due to https://github.com/LP-Reol/PDxx/pull/6.
Then problem was that if the reason for the fault persisted - as in the case of removing the motor supply - then there is no additional rising edge to trigger a fault reset when the supply returns.
As a quick fix we are now continuously flipping the fault reset bit when there is a fault, in order to make sure we generate rising edges to reset the fault state.

This is probably not the best idea, because we now resets _any_ fault state as soon as it is possible to reset it.
As we have very rarely needed to reset faults, it is not an issue in our current setup - the _only_ fault we have encountered recently is the undervoltage one - and as we do not poll the SDOs for fault reporting, then we have no idea what is  going on.

But down the line we should check the SDO fault registers (`0x1003`) when we're encountering a fault condition